### PR TITLE
Added password toggle and improved UI

### DIFF
--- a/firebase.js
+++ b/firebase.js
@@ -131,3 +131,12 @@ document.getElementById('loginForm').addEventListener('submit', function (e) {
   // Call the login function
   loginWithEmailAndPassword(email, password);
 });
+
+function togglePassword(fieldId) {
+  const passwordField = document.getElementById(fieldId);
+  if (passwordField.type === "password") {
+    passwordField.type = "text";
+  } else {
+    passwordField.type = "password";
+  }
+}

--- a/login.css
+++ b/login.css
@@ -92,7 +92,7 @@ body {
 .input-field label {
     display: block; 
     margin-bottom: 0.5rem; 
-    font-weight: bold; 
+    font-weight: 600; 
 }
 
 .input-field input {
@@ -131,9 +131,29 @@ body {
 .signUp-link a {
     color: #3066dc; /* Match the link color with the theme */
     text-decoration: none; /* Remove underline from the link */
-    font-weight: 100; /* Make the link text bold */
+    font-weight: 300; /* Make the link text bold */
 }
 
 .signUp-link a:hover {
     text-decoration: underline; /* Add underline on hover for better UX */
+}
+
+.req{
+    color: red;
+}
+
+.toggle-password {
+    cursor: pointer;
+    position: absolute;
+    right: 10px;
+    top: 55%;
+}
+
+.input-field {
+    position: relative;
+}
+
+.toggle-password svg {
+    width: 20px;
+    height: 20px;
 }

--- a/login.html
+++ b/login.html
@@ -44,12 +44,19 @@
 
             <form id="loginForm" action="book.html" method="POST">
                 <div class="input-field">
-                    <label for="email">Email:</label>
+                    <label for="email">Email<span class="req">*</span></label>
                     <input type="email" id="email" name="email" required />
                 </div>
                 <div class="input-field">
-                    <label for="password">Password:</label>
+                    <label for="password">Password<span class="req">*</span></label>
                     <input type="password" id="password" name="password" required />
+                    <span class="toggle-password" onclick="togglePassword('password')">
+                        <!-- Eye SVG Icon -->
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8S1 12 1 12z"></path>
+                          <circle cx="12" cy="12" r="3"></circle>
+                        </svg>
+                    </span>
                 </div>
                 <div class="input-field">
                     <button type="submit">Continue</button>

--- a/signUp.css
+++ b/signUp.css
@@ -89,7 +89,7 @@ body {
 .input-field label {
     display: block; 
     margin-bottom: 0.4rem; 
-    font-weight: bold; 
+    font-weight: 600; 
     font-size: medium;
 }
 
@@ -127,9 +127,29 @@ body {
 .signin-link a {
     color: #3066dc; /* Match the link color with the theme */
     text-decoration: none; /* Remove underline from the link */
-    font-weight: 100; /* Make the link text bold */
+    font-weight: 300; /* Make the link text bold */
 }
 
 .signin-link a:hover {
     text-decoration: underline; /* Add underline on hover for better UX */
+}
+
+.req{
+    color: red;
+}
+
+.toggle-password {
+    cursor: pointer;
+    position: absolute;
+    right: 10px;
+    top: 55%;
+}
+
+.input-field {
+    position: relative;
+}
+
+.toggle-password svg {
+    width: 20px;
+    height: 20px;
 }

--- a/signUp.html
+++ b/signUp.html
@@ -48,25 +48,34 @@
 
         <form id="signupForm" action="book.html" method="POST">
           <div class="input-field">
-            <label for="name">Full Name:</label>
+            <label for="name">Full Name<span class="req">*</span></label>
             <input type="text" id="name" name="name" required />
           </div>
           <div class="input-field">
-            <label for="email">Email:</label>
+            <label for="email">Email<span class="req">*</span></label>
             <input type="email" id="email" name="email" required />
           </div>
           <div class="input-field">
-            <label for="password">Password:</label>
+            <label for="password">Password<span class="req">*</span></label>
             <input type="password" id="password" name="password" required />
+            <span class="toggle-password" onclick="togglePassword('password')">
+              <!-- Eye SVG Icon -->
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8S1 12 1 12z"></path>
+                <circle cx="12" cy="12" r="3"></circle>
+              </svg>
+            </span>
           </div>
           <div class="input-field">
-            <label for="confirm-password">Confirm Password:</label>
-            <input
-              type="password"
-              id="confirm-password"
-              name="confirm-password"
-              required
-            />
+            <label for="confirm-password">Confirm Password<span class="req">*</span></label>
+            <input type="password" id="confirm-password" name="confirm-password" required />
+            <span class="toggle-password" onclick="togglePassword('confirm-password')">
+              <!-- Eye SVG Icon -->
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8S1 12 1 12z"></path>
+                <circle cx="12" cy="12" r="3"></circle>
+              </svg>
+            </span>
           </div>
           <div class="input-field">
             <button type="submit">Sign Up</button>


### PR DESCRIPTION
Issue: #279 

# Description
- Password Toggle: Add a clickable eye icon beside the password fields and use JavaScript to toggle the type attribute between "password" and "text" to show or hide the password.

- Validation Feedback: Add an asterisk (*) after each field label (Full Name*, Email*, etc.) using HTML/CSS for required fields.

- Update Contrast: Modify the CSS color property of the "Sign in" link to a darker shade (e.g., #000 or a color with higher contrast) to meet accessibility standards for better readability.

# Type of PR
- [x] Feature enhancement

# Screenshots / videos (if ap
- Before:
![brave_XASPXylWHd](https://github.com/user-attachments/assets/ea8cb36a-64f6-4da4-abc7-0e4f2cbed864)
applicable)
![brave_KJMl8UCy3d](https://github.com/user-attachments/assets/93bc9b64-544a-49e8-a94c-c091da59cbca)

- After:
![brave_6peSCnjuiz](https://github.com/user-attachments/assets/d20c87ca-f151-4387-aeb3-ffaa16355047)
![brave_W5R1Dnd9YI](https://github.com/user-attachments/assets/5eee7c4a-fb49-4bba-964a-4834c88b14d4)

# Checklist:
- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

