### PR TITLE
FIXES ISSUE #315: BUG: Rate Your Experience Page in dark mode while page is in light mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -734,7 +734,7 @@ justify-content: center;
 }
 
 .review-form {
-  background: #CCE9F9;
+  background: #ffffff;
   padding: 30px;
   border-radius: 8px;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
@@ -951,8 +951,12 @@ justify-content: center;
   border-color: #ccc;
 }
 
+.light-mode .reviews-section{
+  background-color: white;
+}
+
 /* Dark Mode Styles for Reviews Section */
-.dark-mode .reviews-section {
+.dark-mode .reviews-section  {
   background-color: #121212; /* Dark background */
   color: white; /* White text */
 }
@@ -977,7 +981,7 @@ justify-content: center;
 }
 
 /* Dark Mode Styles for Review Form */
-.review-form {
+.dark-mode .review-form {
   background-color: #121212; /* Dark background for the review form */
   color: white; /* White text color */
   padding: 20px; /* Padding for inner spacing */
@@ -994,9 +998,10 @@ justify-content: center;
   display: block; /* Makes the label block-level for better spacing */
 }
 
-.review-form input,
-.review-form select,
-.review-form textarea {
+.dark-mode .review-form input,
+.dark-mode .review-form select,
+.dark-mode .review-form textarea
+{
   width: 100%; /* Full width */
   padding: 10px; /* Padding inside fields */
   background-color: #1e1e1e; /* Dark background for inputs */


### PR DESCRIPTION
Fixes:  #315 

# Description

Previously the rate your experience section of the page was in dark mode while the page was in light mode.
Now it is changed to light mode.


# Type of PR

- [ ] Bug fix


# Screenshots / videos (if applicable)
Before
![image](https://github.com/user-attachments/assets/eac4d49e-82be-4ece-8360-677342512530)
After
![image](https://github.com/user-attachments/assets/2dbafbac-1736-4479-8fe0-15d781ec8edd)


# Checklist:



- [ ] I have made this change from my own.
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] My changes generate no new warnings.
- [ ] I have tested the changes thoroughly before submitting this pull request.
- [ ] I have provided relevant issue numbers and screenshots after making the changes.

