### PR TITLE
Fixed back button color in login/signup page

### DIFF
--- a/auth.css
+++ b/auth.css
@@ -445,10 +445,18 @@ form.sign-in-form {
   top: 20px;
   left: 20px;
   background: #ffffff;
-  color: #ffffff;
+  color: #000000;
   padding: 10px;
   border-radius: 10px;
   cursor: pointer;
   transition: 0.3s;
   text-decoration: none;
+}
+
+.homeBtn:hover {
+  background: #232323;
+}
+
+.homeBtn:active {
+  background: #191919;
 }


### PR DESCRIPTION
# BUG:Make Back to Home button visible on login/signup page

Fixes:  #457

# Description

Earlier the back to home button icon was not visible in login and isgnup page due to same color.
I have fixed the issue making the button visible and easy to find.
![Screenshot 2024-10-10 131955](https://github.com/user-attachments/assets/ce197c1c-403d-40d8-a523-8bf3c7c16935)
Home button is now easy to find


# Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
[Attach any relevant screenshots or videos demonstrating the changes. Make sure to attach before & after screenshots in your PR.]

# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [x] I have made this change from my own.
- [ ] I have taken help from some online resources.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

