### PR TITLE
Change the text color of heading of home page

### DIFF
--- a/style.css
+++ b/style.css
@@ -336,6 +336,11 @@ nav {
 
 }
 
+.hero h2{
+  color: white;
+  font-size: 6rem;;
+}
+
 .hero h3 {
   font-size: 25px;
   line-height: 40px;


### PR DESCRIPTION
# Related Issue
Feat:Text Not Visible #612

Fixes:  #issue no.612

# Description
The text of heading is not visible on the home page. I've improve it.

Issue no. = #612

# Type of PR
- [ ] Feature enhancement


# Screenshots / videos (if applicable)
Before :
![Screenshot 2024-10-13 164840](https://github.com/user-attachments/assets/203c409e-fc06-4dc9-9a4b-7f6eddcc3b14)

After:
![Screenshot 2024-10-13 203156](https://github.com/user-attachments/assets/2e6ec404-5856-48c4-9d2d-196646e2ff47)


# Checklist:
- [x ] I have made this change from my own.
- [ x] My code follows the style guidelines of this project.
- [ x] I have performed a self-review of my own code.
- [ x] My changes generate no new warnings.
- [x ] I have tested the changes thoroughly before submitting this pull request.
- [x ] I have provided relevant issue numbers and screenshots after making the changes.

