### PR TITLE
Added Margin Gap Between "Travel Itineraries" and "Book a Cab or Auto…

### DIFF
--- a/chatbot.css
+++ b/chatbot.css
@@ -122,3 +122,21 @@ body {
 #close-button:hover {
     color: #dbe913;
 }
+
+
+#itineraries{
+    margin-bottom: 70px;
+    border: none
+}
+
+.itinerary-list{
+    padding-bottom: 30px;
+}
+
+#cab-booking{
+    margin-top: 70px;
+}
+
+#deals{
+    margin-bottom: 10px;
+}

--- a/index.html
+++ b/index.html
@@ -633,7 +633,8 @@
             ages.
           </p>
           <button>View Itinerary</button>
-        </div></div>
+        </div>
+      </div>
 
         <div class="itinerary">
           <div class="header2"> 
@@ -653,6 +654,7 @@
           </p>
           <button>View Itinerary</button>
         </div>
+      </div>
       </div>
     </section>
 


### PR DESCRIPTION
Fixes:  #(issue no.) #848 

# Description

The "Travel Itineraries" section and the "Book a Cab or Auto" section appear too close to each other, making the layout seem crowded and less visually appealing. There is no clear separation between these two sections, which can affect readability and user experience. I fixed this issue. 

before
![Screenshot 2024-10-16 223457](https://github.com/user-attachments/assets/081e2c8a-5103-4a88-9b3f-1c6f5151481e)

after
![Screenshot 2024-10-16 225831](https://github.com/user-attachments/assets/222ef1cf-64e4-4e3a-b042-9033f0c1d061)


Please review this merge this pr.



