### PR TITLE
Fix: Add Font Awesome CDN to Restore Social Media Icons

### DIFF
--- a/contributor/contributor.html
+++ b/contributor/contributor.html
@@ -6,6 +6,15 @@
     <title>BuddyTrail Contributors</title>
     <link rel="stylesheet" href="/style.css">
     <link rel="stylesheet" href="contributor.css">
+    
+    <!-- fontAwsome cdn -->
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css"
+      integrity="sha512-Kc323vGBEqzTmouAECnVceyQqyqdsSiqLQISBL29aUW4U/M7pSPA/gEUZQqv1cwx4OnYxTxve5UMg5GT6L4JJg=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
 </head>
 <body>
   <header class="main-head">


### PR DESCRIPTION
# Related Issue

None

# Fixes:  #860

# Description

Resolves issue #860 by adding Font Awesome CDN to restore missing social media icons in the contributor page footer.

# Type of PR

- [x] Bug fix


# Screenshots 
Before 
![image](https://github.com/user-attachments/assets/4fa03a14-6cb6-43e1-8cde-aecb4dee8911)

After
![image](https://github.com/user-attachments/assets/d384b09c-30b3-4aab-b63f-0a8e8d43b94f)



# Checklist:


- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

