### PR TITLE
🛠️Fix: Calendar Date Validation to Restrict Past Dates

### DIFF
--- a/index.html
+++ b/index.html
@@ -743,9 +743,17 @@
         </div>
 
           <div class="form-group">
-            <label for="travel-date" style="font-size: 15px;"><strong>Travel Date</strong></label>
-            <input type="date" id="travel-date" name="travel-date" required />
-          </div>
+          <label for="travel-date" style="font-size: 15px;"><strong>Travel Date</strong></label>
+          <input type="date" id="travel-date" name="travel-date" required min="" />
+
+          <!--Logic To prevent the user from selecting an old date  -->
+
+          <script>
+            const today = new Date().toISOString().split('T')[0];
+            document.getElementById('travel-date').setAttribute('min', today);
+          </script>
+
+        </div>
           <div class="form-group">
             <label for="travel-time" style="font-size: 15px;"><strong>Travel Time</strong></label>
             <input type="time" id="travel-time" name="travel-time" required />


### PR DESCRIPTION
# Related Issue

None

# Fixes:  #857

# Description

Updates the calendar date validation to prevent users from selecting dates prior to the current date, ensuring valid and up-to-date submissions.


# Type of PR

- [X] Bug fix


# Screenshots 

Before 
![image](https://github.com/user-attachments/assets/4463edf8-f198-483f-b916-59c6f6073fd4)

After 
![image](https://github.com/user-attachments/assets/b7f5bacb-1116-4de3-8c23-3938c4e0024a)



# Checklist:


- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

