### PR TITLE
Removed white spaces on right side in mobile view

### DIFF
--- a/index.html
+++ b/index.html
@@ -966,7 +966,6 @@
         }
 
         #content-input{
-          width: 400px;
           height: 200px;
           border-color: #81c784;
         }


### PR DESCRIPTION
# Related Issue

None

Fixes:  # 927

# Description

This PR removes the white space at the right side when we see the home page in mobile view.
It solves issue #927.

# Type of PR

- [X] Bug fix
- [X] Feature enhancement

# Screenshots / videos (if applicable)
Before:
![Screenshot (697)](https://github.com/user-attachments/assets/ee6482e0-9bf9-46ae-b36d-946e9a0f4c98)
After:
![Screenshot (699)](https://github.com/user-attachments/assets/27d5a53b-c768-4766-a54e-aa61e95f26e8)

# Checklist:

- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

Kindly add the tags of gssoc-ext, hacktoberfest and hacktoberfest-accepted before merging the PR.