### PR TITLE
added sticky header and opacity change

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -10,13 +10,11 @@
     <link href='https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css' rel='stylesheet'>
 </head>
 <style>
-   
    .card {
         width: 50%; /* Set a specific width */
         margin: 10px auto; /* Center horizontally with automatic margins */
         padding: 20px; /* Add padding */
         margin-bottom: 70px;
-       
         border: 1px solid #ccc; /* Optional: Add a border */
         border-radius: 8px; /* Optional: Add rounded corners */
         box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1); /* Optional: Add shadow */
@@ -97,12 +95,33 @@
     margin-top: 5px;
     display: none; /* Hide by default */
 }
-    
+
+    /* Fixed header styles */
+    header {
+        background-color: black;
+        position: fixed;
+        top: 0;
+        height: 85px;
+        width: 100%;
+        z-index: 1000;
+        transition: background-color 0.3s ease, opacity 0.3s ease;
+    }
+
+    /* Sticky effect and opacity changes */
+    header.sticky {
+        background-color: rgba(0, 0, 0, 0.9);
+        opacity: 0.9;
+    }
+
+    /* Adjust the content below the header */
+    .container-fluid {
+        margin-top: 85px; /* Space for the fixed header */
+    }
     
 </style>
 <body>
     <div class="container-fluid">
-    <header style="background-color: black;height:85px" >
+    <header>
         <nav style="padding: 5px;width:90%">
             <div class="logo">
               <img src="img/logo.png" id="logo-web">
@@ -195,5 +214,16 @@ window.gtranslateSettings = {
 ></script>
 
 <script src="./contact.js"></script>
+
+<script>
+    window.onscroll = function() {
+        var header = document.querySelector("header");
+        if (window.pageYOffset > 0) {
+            header.classList.add("sticky");
+        } else {
+            header.classList.remove("sticky");
+        }
+    };
+</script>
 </body>
 </html>


### PR DESCRIPTION
# Related Issue

In contact section when scrolling the navbar is also being scrolled and i also want to add improved opacity feature like home section when content is scrolled for navbar.

Fixes:#1122

# Description
This pull request introduces a sticky header feature that enhances the navigation experience by keeping the header fixed at the top of the page while scrolling. The header's background color and opacity change dynamically to improve visibility against the content as the user scrolls. This enhancement aims to provide a better user experience by ensuring that navigation remains accessible without interfering with the content below.

No additional dependencies are required for this change.

issue number =#1122

# Type of PR


- [x] Feature enhancement


# Screenshots / videos (if applicable)
before:

https://github.com/user-attachments/assets/b56d2a0d-822a-43de-9119-064da75ca9e5

after:

https://github.com/user-attachments/assets/e7f54b36-5b34-418f-8549-8eaa19541631




# Checklist:



- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

