### PR TITLE
Added the CLOSE (x) button to the pop up menu to make it simple and elegant (#1148)

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,25 @@
        border-radius:8px;
        padding: 4px 8px 4px 8px;
      }
+
+      <!-- Close Button -->
+        <div class="close" onclick="closePopup()">
+          <span></span>
+          <span></span>
+          <span></span>
+          <span></span>
+          <svg viewBox="0 0 36 36" class="circle">
+            <path
+              stroke-dasharray="100, 100"
+              d="M18 2.0845
+                a 15.9155 15.9155 0 0 1 0 31.831
+                a 15.9155 15.9155 0 0 1 0 -31.831"
+            />
+          </svg>
+        </div>
+  </div>
+</div>
+      
     /* Button Styling */
     .btn {
       background-color: #007bff; /* Primary button color */
@@ -2709,6 +2728,11 @@ document.getElementById('newsletter-form').addEventListener('submit', function (
     
     </script>
  
+
+ <script> 
+    function closePopup() {
+      document.getElementById('popup').style.display = 'none';
+  }</script> 
  
 </body>
 

--- a/style.css
+++ b/style.css
@@ -1,6 +1,88 @@
 /**** GLOBAL STYLES ****/
 @import url("https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap");
 
+
+/* Popup Styling */
+.popup {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.7); /* Dim background */
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+#popup-content {
+  position: relative;
+  background-color: white;
+  padding: 20px;
+  width: 500px;
+  border-radius: 10px;
+  display: flex;
+  justify-content: space-between;
+}
+
+/* Close Button Styling */
+.close {
+  position: absolute;
+  top: 10px; /* Adjusted position */
+  right: 10px; /* Adjusted position */
+  cursor: pointer;
+  display: inline-block;
+  width: 24px; /* Smaller size */
+  height: 24px; /* Smaller size */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.close svg {
+  width: 24px; /* Smaller size */
+  height: 24px; /* Smaller size */
+  stroke: red;
+  stroke-width: 2;
+  fill: none;
+}
+
+.close span {
+  position: absolute;
+  width: 2px;
+  height: 12px; /* Adjusted size */
+  background-color: red;
+  transform-origin: center;
+  transition: transform 0.25s ease-in-out;
+}
+
+.close span:nth-child(1) {
+  transform: rotate(45deg);
+}
+
+.close span:nth-child(2) {
+  transform: rotate(-45deg);
+}
+
+.close span:nth-child(3), .close span:nth-child(4) {
+  display: none;
+}
+
+.close:hover span:nth-child(1) {
+  transform: rotate(0deg);
+}
+
+.close:hover span:nth-child(2) {
+  transform: rotate(0deg);
+}
+
+/* Circle SVG Style */
+.close svg .circle {
+  stroke: red;
+  stroke-width: 2;
+}
+
+
 * {
   margin: 0;
   padding: 0;


### PR DESCRIPTION


**_Related Issue_**
Fixes: #12027

_**Description**_
Added a close button to the popup menu that appears on the webpage. This button allows users to dismiss the popup by clicking on the "X" located at the top right corner. The button size was customized to be smaller (24x24px) to ensure it does not interfere with the overall popup layout. The close functionality was implemented using a simple JavaScript function to hide the popup when clicked.

**_Motivation:_** This enhancement was necessary to provide a better user experience, allowing users to easily exit the popup without interacting with other elements.
Dependencies: No additional dependencies are required for this change.

_**Type of PR**_
Feature enhancement

Before:
![Screenshot 2024-10-19 103630](https://github.com/user-attachments/assets/1e962147-9c69-45ed-a430-fd7ac7640b08)

After:
![Screenshot 2024-10-20 125334](https://github.com/user-attachments/assets/7d80a8b4-d750-4069-bee0-8fe924c037aa)

video :

https://github.com/user-attachments/assets/9d9725ae-f358-4366-8362-cc5732e2d77c





Checklist:
I have made this change from my own.
My code follows the style guidelines of this project.
I have performed a self-review of my own code.
I have commented my code, particularly in hard-to-understand areas.
I have tested the changes thoroughly before submitting this pull request.
I have provided relevant issue numbers and screenshots after making the changes.


Im a GSSOC -Ext and Hacktober fest contributor !