### PR TITLE
fix #1278 : forgot password now shows up on login screen

### DIFF
--- a/auth.html
+++ b/auth.html
@@ -26,10 +26,10 @@
             <div class="login">
               <input type="submit" value="Login" class="btn solid" />
             </div>
-            <p class="social-text">OR</p>
-            <p class="social-text">Sign in with social platforms</p>
+            <a href="/forgot_password.html" style="text-decoration: none; color: black;"><p>Forgot Password?</p></a>
+            <p class="social-text">OR<br>Sign in with social platforms</p>
 
-            <div class="social-media"> 
+            <div class="social-media">
               <button class="social-icon" id="googleSignInBtn">
 
             <div class="social-media">
@@ -99,7 +99,7 @@
       <i class="fas fa-home"></i>
     </a>
     <div id="toast-container"></div>
-    
+
     <script src="https://www.gstatic.com/firebasejs/9.18.0/firebase-app-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.18.0/firebase-auth-compat.js"></script>
     <script src="firebase.js"></script>
@@ -145,7 +145,7 @@
 
   </script>
 
-  <script 
+  <script
     src="https://cdn.gtranslate.net/widgets/latest/float.js"
     defer
   ></script>


### PR DESCRIPTION
# Related Issue
Fixes:  #1278 

# Description
forgot_password.html existed in codebase but the link to navigate to that page or "forgot password" was not rendering on login screen because the link didn't existed in the auth.html page. So I added that link and now its showing up on the page.

# Type of PR
- [x] Bug fix

# Screenshots / videos (if applicable)
Before : 
![image](https://github.com/user-attachments/assets/59b1d73f-4af9-4b69-a1a4-ad4e3080ccf0)

After : 
![image](https://github.com/user-attachments/assets/454cf521-c220-4943-af3c-22a2338710cd)
![image](https://github.com/user-attachments/assets/61d98874-666d-4fe2-8fe9-55ceb7e8c831)

# Checklist:
- [x] I have made this change from my own.
- [x] I have taken help from some online resources.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

