### PR TITLE
fixed service section not changing to dark mode when theme is changed

### DIFF
--- a/style.css
+++ b/style.css
@@ -1112,7 +1112,7 @@ body {
 }
 
  issue
- 
+
 h2 {
 main
 
@@ -1120,9 +1120,9 @@ main
   font-weight:  700;
   margin:  10px 0; /* Margin adjustment */
   color:  #007bff;
-   
+
 }
- 
+
 p {
   font-size: 1.5em;
   color: #666; /* Paragraph color */
@@ -2939,6 +2939,33 @@ textarea {
   line-height: 1.5;
 }
 
+/* Dark mode for Service */
+.dark-mode #services {
+    background-color: #121212; /* Dark background */
+    color: #e0e0e0; /* Light grey text */
+  }
+
+  .dark-mode #services h1 {
+    color: #ffa500; /* Orange color for the main heading in dark mode */
+  }
+
+  .dark-mode #services h2 {
+    color: #ffa500; /* Bright yellow subheading in dark mode */
+  }
+
+  .dark-mode #services p {
+    color: #e0e0e0; /* darker grey for paragraph text in dark mode */
+  }
+
+  .dark-mode #services p strong {
+    color: #ffa500; /* Yellow highlight for important text in dark mode */
+  }
+
+  .dark-mode .service-card{
+    background-color: #1e1e1e; /* Darker background for service cards */
+    color: #e0e0e0; /* Light grey text color */
+  }
+
 html,
 body {
   margin: 0;
@@ -2962,7 +2989,7 @@ body {
   position: fixed;
   bottom: 70px; /* Adjust for vertical spacing above the icon */
   right: 20px;  /* Adjust for horizontal spacing */
-  z-index: 1000; 
+  z-index: 1000;
   display: none; /* Initially hide the chatbot */
 }
 


### PR DESCRIPTION
# Related Issue
fixes: #1393 

Description
When switching to dark mode, rest of the page changes its style accordingly except the Service section. So i added the dark mode functionality to it whose UI is consistent with the rest of the content, maintaining the uniform colors and style throughout page.

# Type of PR
- [x] Bug fix
- [x] Feature enhancement 

# Screenshots / videos (if applicable)
Before : 
![Screenshot from 2024-10-23 01-51-54](https://github.com/user-attachments/assets/b540ed3f-b7a3-4629-acd6-2fe116cd678d)

After : 
![Screenshot from 2024-10-23 01-52-05](https://github.com/user-attachments/assets/c6cfeae2-f705-4a27-9779-f42d75d08925)

# Checklist:
- [x] I have made this change on my own.
- [x] I have taken help from some online resources.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.