### PR TITLE
Corrected image postioning

### DIFF
--- a/F&Q.html
+++ b/F&Q.html
@@ -264,7 +264,7 @@
         position: absolute;
         width: 250px;
         top: 450px;
-        right: 1250px;
+        right: 1110px;
         mix-blend-mode: multiply;
       "
       src="img/HELP-IMG.jpg"
@@ -273,9 +273,9 @@
     <img
       style="
         position: absolute;
-        width: 250px;
+        width: 320px;
         top: 300px;
-        left: 1250px;
+        left: 1100px;
         mix-blend-mode: multiply;
       "
       src="img/download.jpeg"


### PR DESCRIPTION
# Related Issue

“None”

Fixes:  #1401 

# Description

In the FAQ page the images is not properly aligned due to this the page looks misaligned. So I aligned the images

<!---give the issue number you fixed----->

# Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
Before
![999](https://github.com/user-attachments/assets/ea87cee0-c36d-492d-9497-f5eb4bfd935d)

After
![22](https://github.com/user-attachments/assets/362ff148-22e2-49f4-9c4f-52411e451d3a)


# Checklist:


- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

