### PR TITLE
changed the heading colour in team for light mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -283,7 +283,7 @@ button {
   transition: background-color 0.3s;
 }
 .heading-contributors h2{
-  color: transparent;
+  color: black;
 }
 
 #btn a {


### PR DESCRIPTION
# Related Issue
changed the heading colour in team for light mode

Fixes:  #1484 

# Description
Changed the heading colour of "MEET OUR CONTRIBUTORS" in team for light mode.

<!---1484----->

# Type of PR
- [x] Bug fix

# Screenshots / videos (if applicable)
**Before**
![image](https://github.com/user-attachments/assets/807f9ef7-6b7d-4313-90a6-ca230eae7610)

**After**
![image](https://github.com/user-attachments/assets/09c7fc3d-e430-4b43-91ee-14c2055fca77)


# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

