### PR TITLE
fixed overlapping text in popular destination's card

### DIFF
--- a/book.html
+++ b/book.html
@@ -109,7 +109,7 @@
       }
 
       .footer-bottom {
-        margin-top: 20px; 
+        margin-top: 20px;
       }
     </style>
   </head>
@@ -235,7 +235,7 @@
                 luxury at an affordable price!
               </li>
             </ul>
-            <p><strong>Price:</strong> ₹10,500 <del>₹15,000</del> per night</p>
+            <p><strong>Price:</strong> ₹10,500 <del>₹15,000</del> </p>
           </div>
           <div
             class="location-card"
@@ -251,7 +251,7 @@
                 4-day, 3-night package. All-inclusive deal!
               </li>
             </ul>
-            <p><strong>Price:</strong> ₹10,500 <del>₹15,000</del> per night</p>
+            <p><strong>Price:</strong> ₹10,500 <del>₹15,000</del> </p>
           </div>
           <div
             class="location-card"
@@ -267,7 +267,7 @@
                 package for couples!
               </li>
             </ul>
-            <p><strong>Price:</strong> ₹10,500 <del>₹15,000</del> per night</p>
+            <p><strong>Price:</strong> ₹10,500 <del>₹15,000</del> </p>
           </div>
           <div
             class="location-card"
@@ -283,7 +283,7 @@
                 luxury at an affordable price!
               </li>
             </ul>
-            <p><strong>Price:</strong> ₹10,500 <del>₹15,000</del> per night</p>
+            <p><strong>Price:</strong> ₹10,500 <del>₹15,000</del> </p>
           </div>
 
           <div
@@ -300,7 +300,7 @@
                 best of luxury at an affordable price!
               </li>
             </ul>
-            <p><strong>Price:</strong> ₹10,500 <del>₹15,000</del> per night</p>
+            <p><strong>Price:</strong> ₹10,500 <del>₹15,000</del> </p>
           </div>
 
           <div
@@ -317,7 +317,7 @@
                 package for couples!
               </li>
             </ul>
-            <p><strong>Price:</strong> ₹10,500 <del>₹15,000</del> per night</p>
+            <p><strong>Price:</strong> ₹10,500 <del>₹15,000</del> </p>
           </div>
 
           <div
@@ -334,7 +334,7 @@
                 best of luxury at an affordable price!
               </li>
             </ul>
-            <p><strong>Price:</strong> ₹10,500 <del>₹15,000</del> per night</p>
+            <p><strong>Price:</strong> ₹10,500 <del>₹15,000</del> </p>
           </div>
         </div>
       </section>
@@ -493,7 +493,7 @@
 
   </script>
 
-  <script 
+  <script
     src="https://cdn.gtranslate.net/widgets/latest/float.js"
     defer
   ></script>


### PR DESCRIPTION
# Related Issue
fixes:  #1534 

# Description
The texts in the popular destination's card are overlapping and hence are not clear to read. Removing 'per night' text from the card fixes the issue and makes rest of the card consistent with Dubai's card.

# Type of PR
- [x] Bug fix

# Screenshots / videos (if applicable)
Before : 

https://github.com/user-attachments/assets/12125a76-3b14-4a59-a145-702f35df0219

After : 

https://github.com/user-attachments/assets/7863a8d9-80ff-4ff6-9b68-aeab4b91eb34

# Checklist:
- [x] I have made this change from my own.
- [x] I have taken help from some online resources.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

