### PR TITLE
fixed texts in contributors card

### DIFF
--- a/style.css
+++ b/style.css
@@ -229,7 +229,7 @@ body {
 }
 
 h1 {
-  font-size: 2.6rem;
+  font-size: 1.8rem;
 }
 
 h2 {


### PR DESCRIPTION
# Related Issue
Fixes:  #1636 

# Description
Text about contributors in team's page is too big for it to fit in that box. The reason for the problem was predefined h1 tag with size of 2.6 rem which was too large for the texts. Changing it to 1.8 rem fixes the issue.

# Type of PR
- [x] Bug fix

# Screenshots / videos (if applicable)
Before : 

https://github.com/user-attachments/assets/1549f500-2ec9-4148-8e66-465f6505abd8

After : 

https://github.com/user-attachments/assets/05cdda2b-13e9-4359-b0e2-1ae62cc3c241

# Checklist:
- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.
