### PR TITLE
Added placeholders in missing fields of "rate your experience" form

### DIFF
--- a/index.html
+++ b/index.html
@@ -2516,11 +2516,13 @@ textarea.form-control {
           <form class="form" id="reviewForm">
             <label for="name" id="darkbtn" style="color: black;">Your Name:</label>
             <input type="text" id="name" name="name" required pattern="[a-zA-Z ]+"
+            placeholder="Enter your name"
             oninvalid="this.setCustomValidity('Numbers and Symbols are not allowed')"
             oninput="this.setCustomValidity('')"/>
 
             <label for="destination" id="darkbtn" style="color: black;">Destination/Service:</label>
             <input type="text" id="destination" name="destination" required  required pattern="[a-zA-Z ]+"
+            placeholder="Enter your destination or service"
             oninvalid="this.setCustomValidity('Numbers and Symbols are not allowed')"
             oninput="this.setCustomValidity('')"/>
 


### PR DESCRIPTION
Fixes:  #1697 

# Description
Placeholders for two inputs were missing in the "Rate your experience" form.. I have added the relevant placeholders.

Before:
![Capturefrgtgty](https://github.com/user-attachments/assets/1e93820d-da87-49ef-a607-316248b5175b)
After:
![Capturemkmk](https://github.com/user-attachments/assets/fc7d01e1-0437-4c26-9ff6-fc6b3588ef66)

@PriyaGhosal Kindly review the PR and add the gssoc, hacktoberfest and level labels...

# Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Checklist:

- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

