### PR TITLE
added rate limit api to login api

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,1 +1,2 @@
 .env
+/node_modules

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.21.1",
+        "express-rate-limit": "^7.4.1",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.7.3"
       }
@@ -355,6 +356,21 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.4.1.tgz",
+      "integrity": "sha512-KS3efpnpIDVIXopMc65EMbWbUht7qvTCdtCR2dD/IZmi9MIkopYESwyRqLgv8Pfu589+KqDqOdzJWW7AHoACeg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "4 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/express/node_modules/cookie": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.21.1",
+    "express-rate-limit": "^7.4.1",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.7.3"
   }

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -1,11 +1,26 @@
-const express = require('express');
-const { signup, login, logout, verifyToken } = require('../controllers/authController');
+const express = require("express");
+const rateLimit = require("express-rate-limit");
+const {
+  signup,
+  login,
+  logout,
+  verifyToken,
+} = require("../controllers/authController");
 
 const router = express.Router();
 
-router.post('/signup', signup);
-router.post('/login', login);
-router.post('/logout', logout);
-router.get('/verify', verifyToken); // New verification route
+// Set up rate limiter for the login route
+const loginRateLimiter = rateLimit({
+  windowMs: 5 * 60 * 1000, // 5 minutes
+  max: 5,
+  message: "Too many login attempts. Please try again in 5 minutes.",
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+router.post("/signup", signup);
+router.post("/login", loginRateLimiter, login); // Apply the limiter here
+router.post("/logout", logout);
+router.get("/verify", verifyToken);
 
 module.exports = router;


### PR DESCRIPTION
i added a rate limit middleware to the login  api   issue number #1695
here how it works:
login with correct credentials is success
![Screenshot (26)](https://github.com/user-attachments/assets/b83bbc21-014d-4506-8bf8-a789c1cd2000)
login with wrong credentials is unsuccesfull
![Screenshot (27)](https://github.com/user-attachments/assets/60cb1f17-db02-4ee7-a083-381cfd638b00)
when anyone try to login with wrong credentials manyy times it block that  ip address for 5 minutes
![Screenshot (28)](https://github.com/user-attachments/assets/6af1eaf5-e717-4350-bcc2-1c736f0a2a53)


advantage:
prevent bot brute force attack
reduce the load on api

please review this pr and add gssoc-ext and level2 label before merge @PriyaGhosal 