### PR TITLE
Extra text remove from FAQ page and enhnaced all right reserved text

### DIFF
--- a/F&Q.html
+++ b/F&Q.html
@@ -632,7 +632,7 @@ body.dark-mode .navbar a:hover {
   });
     </script>  
   </body>
-=======
+ 
     
 
   <footer id="footer">
@@ -730,7 +730,7 @@ body.dark-mode .navbar a:hover {
   
     <!-- Footer Bottom Section -->
     <div class="footer-bottom">
-      <p class="copyright-b">&copy; 2024 BuddyTrail. All rights reserved.</p>
+      <p class="copyright-b" style="font-size: medium;">&copy; 2024 BuddyTrail. All rights reserved.</p>
     </div>
   </footer>
   <script>
@@ -793,7 +793,7 @@ modeToggle.addEventListener("click", () => {
         document.getElementById("clipart-img1").style.visibility = "visible";
         document.getElementById("clipart-img2").style.visibility = "visible";
     }
-});
+  });
 });
   </script>
 </body>


### PR DESCRIPTION
# Related issue

extra text remove and text styled omprove 
Fixes:  #1718 
# Description

 in FAQ page i see there is extra text occur in the left side of bottom of footer also the all right reserved text is very small in size i improve its style to make it more visible.



<!---give the issue number you fixed----->

# Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
 
Before:

![WhatsApp Image 2024-10-28 at 15 57 56_144398be](https://github.com/user-attachments/assets/8a0f0b1c-e189-49b2-9e62-5d1fea15064c)

After:

![WhatsApp Image 2024-10-28 at 16 03 59_9d75f1b9](https://github.com/user-attachments/assets/faf8962d-592e-4db5-89f8-2c522a90a77e)

# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [x] I have made this change from my own.
- [x] I have taken help from some online resources.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

