### PR TITLE
Modified Carousel to display properly

### DIFF
--- a/index.html
+++ b/index.html
@@ -912,7 +912,7 @@ p {
 .carousel {
   position: relative;
   overflow: hidden;
-  width: 90vw;
+  width: 940px;
   max-width: 1000px;
   margin: 0 auto;
   height: 450px;
@@ -928,7 +928,8 @@ p {
 
 /* Deal Item Styling */
 .deal-item {
-  min-width: 280px;
+  min-width: 300px;
+  flex: 0 0 300px;
   box-sizing: border-box;
   padding: 25px;
   background: #ffffff; /* Start with a clean white background */
@@ -1052,7 +1053,7 @@ p {
 
           // Update the transform to show the correct slides
           const carouselInner = document.querySelector('.carousel-inner');
-          carouselInner.style.transform = `translateX(-${currentSlide * (100 / slidesToShow)}%)`;
+          carouselInner.style.transform = `translateX(-${currentSlide * (129.5 / slidesToShow)}%)`;
 
           // Remove highlight class from all cards
           slides.forEach(slide => slide.classList.remove('highlight'));


### PR DESCRIPTION
# Related Issue

Modified the carousel on the home page to show the correct number of tiles.

Fixes:  #1491 

# Description

Earlier uneven number of carousel was shown , but now within each slider only 3 carousel tiles are shown.

<!---1491----->

# Type of PR

- [x] Bug fix

# Screenshots / videos (if applicable)
**Before Change**
![image](https://github.com/user-attachments/assets/009980f2-81ed-4526-bf31-fa7d4d33564a)

**After Change**
![image](https://github.com/user-attachments/assets/d996e232-ee2e-411b-bee7-a999846ec58a)

# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

