### PR TITLE
Extra text remove from FAQ page and enhnaced all right reserved text

### DIFF
--- a/F&Q.html
+++ b/F&Q.html
@@ -632,7 +632,7 @@ body.dark-mode .navbar a:hover {
   });
     </script>  
   </body>
-=======
+ 
     
 
   <footer id="footer">
@@ -730,7 +730,7 @@ body.dark-mode .navbar a:hover {
   
     <!-- Footer Bottom Section -->
     <div class="footer-bottom">
-      <p class="copyright-b">&copy; 2024 BuddyTrail. All rights reserved.</p>
+      <p class="copyright-b" style="font-size: medium;">&copy; 2024 BuddyTrail. All rights reserved.</p>
     </div>
   </footer>
   <script>
@@ -793,7 +793,7 @@ modeToggle.addEventListener("click", () => {
         document.getElementById("clipart-img1").style.visibility = "visible";
         document.getElementById("clipart-img2").style.visibility = "visible";
     }
-});
+  });
 });
   </script>
 </body>


### PR DESCRIPTION
# Related Issue

extra text and all  right resaved  text styled enhanced
 

Fixes:  #1718 

# Description

 extra text fix faq page left top side of over the footer.  
 

# Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
 Before:
![WhatsApp Image 2024-10-28 at 15 57 56_03cf2046](https://github.com/user-attachments/assets/bfa97eef-525f-49fa-b04c-bba56075a0f0)

After:
![WhatsApp Image 2024-10-28 at 16 03 59_27f91eb9](https://github.com/user-attachments/assets/bf2e76de-6c1e-4c6c-baf8-6ea7a28409b7)


# Checklist:

 

- [x] I have made this change from my own.
- [x] have taken help from some online resources.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

