### PR TITLE
[FIXED] BUG: Link Goa page to the Goa card #1772

### DIFF
--- a/book.html
+++ b/book.html
@@ -258,7 +258,7 @@
                 </div>
                 <div class="location-card" style="
               background-image: url('https://plus.unsplash.com/premium_photo-1697729701846-e34563b06d47?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D');
-            ">
+            " onclick="location.href='goa-resort.html'">
                     <h3>Goa</h3>
                     <ul>
                         <li>Luxury Stay in Goa</li>


### PR DESCRIPTION
# Related Issue

#1772

Fixes:  #1772

# Description

An onclick event was added so that when the user clicks the Goa card, the user is redirected to the Goa page where they can view the resorts.

<!---give the issue number you fixed----->

# Type of PR

- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)


# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [X] I have made this change from my own.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers and screenshots after making the changes.

