### PR TITLE
[FIXED] Feat: Make a page for Italy #1783

### DIFF
--- a/book.html
+++ b/book.html
@@ -328,7 +328,7 @@
 
                 <div class="location-card" style="
               background-image: url('https://images.unsplash.com/photo-1520175480921-4edfa2983e0f?q=80&w=2067&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D');
-            ">
+            " onclick="location.href='italy.html'">
                     <h3>Italy</h3>
                     <ul>
                         <li>Italy Most beautiful countries in the world</li>

--- a/italy.html
+++ b/italy.html
@@ -1,0 +1,233 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Italy Travel - Hotels</title>
+
+    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="./styles/popup.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=Pattaya&family=Poppins:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://kit.fontawesome.com/c4254e24a8.js" crossorigin="anonymous"></script>
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css"
+      integrity="sha512-Kc323vGBEqzTmouAECnVceyQqyqdsSiqLQISBL29aUW4U/M7pSPA/gEUZQqv1cwx4OnYxTxve5UMg5GT6L4JJg=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        background-color: #f4f4f4;
+        margin: 0;
+        width: 100vw;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        overflow-x: hidden;
+      }
+
+      .main-image {
+        width: 100%;
+        height: 300px;
+        object-fit: cover;
+        background-image: url('https://images.pexels.com/photos/236516/pexels-photo-236516.jpeg');
+        background-position: bottom;
+      }
+
+      .main-heading {
+        font-size: 48px;
+        color: white;
+        text-align: center;
+        height: 500px;
+        padding-top: 120px;
+      }
+
+      .container {
+        text-align: center;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        margin: auto;
+        width: 100vw;
+      }
+
+      .card-container {
+        display: flex;
+        flex-direction: row;
+        width: 100vw;
+        height: 590px;
+        align-items: center;
+        margin: auto;
+        margin-left: 100px;
+        margin-bottom: 50px;
+      }
+
+      h1 {
+        color: #2c3e50;
+        margin-bottom: 30px;
+        font-size: 5em;
+      }
+
+      .hotel-card {
+        background-color: #ffffff;
+        border: 1px solid #ddd;
+        border-radius: 8px;
+        padding: 20px;
+        margin: 15px 40px;
+        box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+        width: 450px;
+        height: 100%;
+      }
+
+      .hotel-image {
+        width: 100%;
+        max-height: 400px;
+        border-radius: 8px;
+        object-fit: cover;
+        height: 100%;
+      }
+
+      .hotel-card h2 {
+        color: #2980b9;
+        margin: 10px 0 10px;
+        font-size: 3rem;
+      }
+
+      .hotel-card p {
+        color: #7f8c8d;
+        font-size: 18px;
+      }
+
+      .book-button {
+        background-color: #2980b9;
+        color: white;
+        border: none;
+        border-radius: 5px;
+        padding: 10px 20px;
+        font-size: 16px;
+        cursor: pointer;
+        transition: background-color 0.3s;
+      }
+
+      .book-button:hover {
+        background-color: #1a6d99;
+      }
+    </style>
+</head>
+<body>
+    <div class="main-image">
+        <h1 class="main-heading">Italy</h1>
+    </div>
+    <br>
+    <br>
+    <h1>Top Hotels in Italy</h1>
+
+    <div class="container">
+        <div class="card-container">
+            <div class="hotel-card">
+              <img
+                src="https://q-xx.bstatic.com/xdata/images/hotel/max1024x768/314431331.jpg?k=5510a414e5d1531b9a75ea58b8fbfb6367a5deac8b1de1ff99762299c0626f86&o=?s=375x210&ar=16x9"
+                alt="Hotel Splendido, Portofino"
+                class="hotel-image"
+              />
+              <h2>Hotel Splendido, Portofino</h2>
+              <p>Price per night: ₹45,990</p>
+              <button class="book-button">Book Now</button>
+            </div>
+            <div class="hotel-card">
+              <img
+                src="https://www.grandhoteltremezzo.com/media/15ifu1em/grand-hotel-tremezzo-facade-ruben-ortiz-new-new.jpg?width=585&height=1012&format=webp&v=1daab84fb44bdf0"
+                alt="Grand Hotel Tremezzo, Lake Como"
+                class="hotel-image"
+              />
+              <h2>Grand Hotel Tremezzo</h2>
+              <p>Price per night: ₹50,990</p>
+              <button class="book-button">Book Now</button>
+            </div>
+            <div class="hotel-card">
+              <img
+                src="https://www.villadeste.com/wp-content/uploads/2023/02/Villa-dEste_Drone-View.jpg"
+                alt="Hotel Villa d'Este, Lake Como"
+                class="hotel-image"
+              />
+              <h2>Hotel Villa d'Este</h2>
+              <p>Price per night: ₹55,990</p>
+              <button class="book-button">Book Now</button>
+            </div>
+          </div>
+
+      <div class="card-container">
+        <div class="hotel-card">
+          <img
+            src="https://cf.bstatic.com/xdata/images/hotel/max1024x768/591472777.jpg?k=7f4a0525fac60c271a42675f3ade388689390f23f1efef78923c80756d6caa91&o=&hp=1"
+            alt="Hotel Principe di Savoia, Milan"
+            class="hotel-image"
+          />
+          <h2>Principe di Savoia</h2>
+          <p>Price per night: ₹60,990</p>
+          <button class="book-button">Book Now</button>
+        </div>
+        <div class="hotel-card">
+          <img
+            src="https://cdn.blastness.biz/media/1240/top/thumbs/full/1920-salone_feste.jpg"
+            alt="Grand Hotel Plaza, Rome"
+            class="hotel-image"
+          />
+          <h2>Grand Hotel Plaza, Rome</h2>
+          <p>Price per night: ₹65,990</p>
+          <button class="book-button">Book Now</button>
+        </div>
+        <div class="hotel-card">
+          <img
+            src="https://img.belmond.com/f_auto/t_2580x1299/photos/cip/cip-ext-aerial02.jpg"
+            alt="Hotel Cipriani, Venice"
+            class="hotel-image"
+          />
+          <h2>Hotel Cipriani, Venice</h2>
+          <p>Price per night: ₹70,990</p>
+          <button class="book-button">Book Now</button>
+        </div>
+      </div>
+      <div class="card-container">
+        <div class="hotel-card">
+            <img
+              src="https://www.roccofortehotels.com/media/rp1hu5y5/rfh-villa-igiea-9437-jg-sep-19.jpg"
+              alt="Hotel Villa Igiea, Palermo"
+              class="hotel-image"
+            />
+            <h2>Hotel Villa Igiea, Palermo</h2>
+            <p>Price per night: ₹75,990</p>
+            <button class="book-button">Book Now</button>
+          </div>
+          <div class="hotel-card">
+            <img
+              src="https://cf.bstatic.com/xdata/images/hotel/max1024x768/465555986.jpg?k=127dd0ee98567210c68124e376bcc6f9b4efc032b9d8fed28e100e18e9e3a7d7&o=&hp=1"
+              alt="Grand Hotel Excelsior, Florence"
+              class="hotel-image"
+            />
+            <h2>Grand Hotel Excelsior</h2>
+            <p>Price per night: ₹80,990</p>
+            <button class="book-button">Book Now</button>
+          </div>
+          <div class="hotel-card">
+            <img
+              src="https://tyfzvhiz.cdn.imgeng.in/assets/uploads/room-103-ghdm-231041-h-rev.jpg"
+              alt="Hotel Grand Hotel et de Milan, Milan"
+              class="hotel-image"
+            />
+            <h2>Grand Hotel et de Milan</h2>
+            <p>Price per night: ₹85,990</p>
+            <button class="book-button">Book Now</button>
+          </div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
# Related Issue

#1783
Fixes:  #1783

# Description

When the user clicks on the Italy card in the book now page now, the user is redirected to a page showing all the top hotels in Italy along with their prices. #1783

<!---give the issue number you fixed----->

# Type of PR

- [ ] Bug fix
- [X] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
When user clicks on:
<img width="1799" alt="Screenshot 2024-10-30 at 6 49 02 PM" src="https://github.com/user-attachments/assets/e9b9ce84-f884-4ec4-89bd-97e53fcb8451">

The user is redirected to:
<img width="1799" alt="Screenshot 2024-10-30 at 6 50 12 PM" src="https://github.com/user-attachments/assets/50ac886d-09bf-4b2d-be0d-a9bc3bcb8ed6">

New Feature:
https://github.com/user-attachments/assets/664871f4-57da-459e-bddf-39c139287b8e



# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [X] I have made this change from my own.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers and screenshots after making the changes.

