### PR TITLE
Redirecting to Home Page using logo and logo text On Blog and About pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -138,7 +138,7 @@
   <nav >
     <div class="logo">
       <img src="img/logo.png" id="logo-web">
-      <h1 id="logo"><a href="#home">BuddyTrail</a></h1>
+      <h1 id="logo"><a href="index.html">BuddyTrail</a></h1>
     </div>
 
     <!-- Hamburger button for mobile -->
@@ -617,8 +617,9 @@
         .hover-color:hover {
             color: rgb(199, 59, 159);
             /* Change color on hover */
-=======
+
         /* Navbar style */
+        }
 
         .nav-link {
             position: relative;

--- a/blog.html
+++ b/blog.html
@@ -614,7 +614,7 @@
     <header class="main-head">
         <div class="logo">
           <img src="img/logo.png" id="logo-web" />
-          <h1 id="logo"><a href="#home">BuddyTrail</a></h1>
+          <h1 id="logo"><a href="index.html">BuddyTrail</a></h1>
         </div>
         <nav>
           <ul id="nav-list">


### PR DESCRIPTION
# Related Issue

[Cite any related issue(s) this pull request addresses. If none, simply state “None”]

Fixes:  #(1797.)

# Description

The feature involves enabling proper navigation through clickable elements like the logo or a “Buddytrail” text. When users click on these elements, they should be not-redirected to home when on Team, Blogs, About, FAQ, or Contact-depending on the pages.

<!---give the issue number you fixed----->

#1797 

- [X] Bug fix
- [X] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
Before


https://github.com/user-attachments/assets/a41a01dc-277e-4146-9411-18280cc9f969



After



https://github.com/user-attachments/assets/0d833c61-e456-43ad-b1b8-0b26dce421a7



# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [X] I have made this change from my own.
- [ ] I have taken help from some online resources.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers and screenshots after making the changes.

