### PR TITLE
[FIXED] Feat: Adding searching and sorting functionality in Paris page #1858

### DIFF
--- a/paris.html
+++ b/paris.html
@@ -50,6 +50,15 @@
         padding-top: 120px;
       }
 
+
+      .top-container {
+        width: 100vw;
+        display: flex;
+        flex-direction: row;
+        justify-content: center;
+
+      }
+
       .container {
         text-align: center;
         display: flex;
@@ -59,8 +68,17 @@
         width: 100vw;
       }
 
+      .seach-container {
+        margin-right: 40px;
+      }
+
+      .sort-container {
+        margin-left: 40px;
+      }
+
       .card-container {
         display: flex;
+        flex-wrap: wrap;
         flex-direction: row;
         width: 100vw;
         height: 590px;
@@ -92,6 +110,7 @@
         max-height: 400px;
         border-radius: 8px;
         object-fit: cover;
+        height: 100%;
       }
 
       .hotel-card h2 {
@@ -129,6 +148,24 @@
     <br>
     <h1>Top Hotels in Paris</h1>
 
+    <!-- Search Bar -->
+    <div class="top-container">
+      <div class="search-container">
+        <label for="search">Search for hotels:</label>
+        <input type="search" id="search" placeholder="Search for a hotel..." />
+      </div>
+
+      <div class="sort-container">
+        <label for="sort">Sort by Price:</label>
+        <select id="sort" name="sort">
+          <option value="featured">Featured</option>
+          <option value="low-to-high">Low to High</option>
+          <option value="high-to-low">High to Low</option>
+        </select>
+      </div>
+    </div>
+
+    <!-- Hotels -->
     <div class="container">
         <div class="card-container">
             <div class="hotel-card">
@@ -228,5 +265,86 @@
           </div>
       </div>
     </div>
+
+    <!-- Sorting Script -->
+    <script>
+      
+      const hotelCards = document.querySelectorAll(".hotel-card");
+      const sortSelect = document.getElementById("sort");
+      const searchInput = document.getElementById("search");
+
+      // Function to filter hotel cards based on search input
+      function filterHotels() {
+        const searchTerm = searchInput.value.toLowerCase();
+        const matchedHotels = []; // Array to store matched hotel cards
+
+        hotelCards.forEach((hotelCard) => {
+          const hotelName = hotelCard
+            .querySelector("h2")
+            .textContent.toLowerCase();
+          if (hotelName.includes(searchTerm)) {
+            matchedHotels.push(hotelCard); // Add matching hotel card to the array
+          }
+        });
+
+        // Clear the card container
+        const cardContainer = document.querySelector(".card-container");
+        cardContainer.innerHTML = "";
+
+        // Append matched hotels to the card container in rows of three
+        matchedHotels.forEach((hotelCard) => {
+          cardContainer.appendChild(hotelCard);
+        });
+      }
+      // Add event listener to search input
+      searchInput.addEventListener("input", filterHotels);
+
+      sortSelect.addEventListener("change", () => {
+        const sortBy = sortSelect.value;
+        let sortedHotels;
+
+        if (sortBy === "featured") {
+          window.location.reload(true);
+          return false;
+        }
+
+        if (sortBy === "low-to-high") {
+          sortedHotels = [...hotelCards].sort((a, b) => {
+            const priceA = parseInt(
+              a
+                .querySelector("p")
+                .textContent.replace("Price per night: ₹", "")
+            );
+            const priceB = parseInt(
+              b
+                .querySelector("p")
+                .textContent.replace("Price per night: ₹", "")
+            );
+            return priceA - priceB;
+          });
+        } else if (sortBy === "high-to-low") {
+          sortedHotels = [...hotelCards].sort((a, b) => {
+            const priceA = parseInt(
+              a
+                .querySelector("p")
+                .textContent.replace("Price per night: ₹", "")
+            );
+            const priceB = parseInt(
+              b
+                .querySelector("p")
+                .textContent.replace("Price per night: ₹", "")
+            );
+            return priceB - priceA;
+          });
+        }
+
+        const cardContainer = document.querySelector(".card-container");
+        cardContainer.innerHTML = "";
+
+        sortedHotels.forEach((hotelCard) => {
+          cardContainer.appendChild(hotelCard);
+        });
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
# Related Issue

#1858
Fixes:  #1858

# Description

On the Paris page where the hotels are displayed there is no option to search hotels by their name or sort the hotel by their price such as 'high to low' or 'low to high' or 'featured.

 I added the following functionalities to the page:
- Sorting
- Searching

<!---give the issue number you fixed----->

# Type of PR

- [ ] Bug fix
- [X] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
The feature looks like:
<img width="784" alt="Screenshot 2024-11-01 at 5 17 24 PM" src="https://github.com/user-attachments/assets/6b6ab089-de31-49a9-af80-b80f85b9a28a">

The feature looks like this on the page:
<img width="1800" alt="Screenshot 2024-11-01 at 5 17 44 PM" src="https://github.com/user-attachments/assets/0290c55e-5cea-4949-982c-ba7c0c68e2c1">

The feature works as follows:
https://github.com/user-attachments/assets/49146f3e-4406-48bd-a8c6-bc8bc5906b44



# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [X] I have made this change from my own.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers and screenshots after making the changes.

