### PR TITLE
Missing icons add in desclaimer page footer

### DIFF
--- a/cookie_policy.html
+++ b/cookie_policy.html
@@ -320,6 +320,7 @@
               ></a>
             </div>
           </div>
+
         </div>
         <p class="copyright">&copy; 2024 BuddyTrail | All rights reserved.</p>
       </div>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -6,7 +6,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="terms.css">
     <title>Disclaimer - BuddyTrail</title>
-   
+    <link rel="icon" href="https://img.icons8.com/?size=100&id=11808&format=png&color=000000" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" />
 </head>
 <style>
      /* Resetting margin and padding */
@@ -448,26 +449,30 @@ main
               
             </div>
             <div class="footer-column">
-              <h3>Follow Us</h3>
-              <div class="social-icons">
-                <a href="https://discord.com/invite/priyaghosal" target="_blank"
-                  ><i class="fab fa-discord"></i
-                ></a>
-                <a href="https://twitter.com/PriyaGhosa39968" target="_blank"
-                  ><i class="fab fa-twitter"></i
-                ></a>
-                <a
-                  href="https://github.com/PriyaGhosal/BuddyTrail"
-                  target="_blank"
-                  ><i class="fab fa-github"></i
-                ></a>
-                <a
-                  href="https://www.linkedin.com/in/priya-ghosal-785771286/"
-                  target="_blank"
-                  ><i class="fab fa-linkedin-in"></i
-                ></a>
-              </div>
+            <h3>Follow Us</h3>
+            <div class="social-icons">
+              <a href="https://discord.com/invite/priyaghosal" target="_blank"
+                ><i class="fab fa-discord"></i
+              ></a>
+              <a href="https://twitter.com/PriyaGhosa39968" target="_blank"
+              class="x-logo-link" >
+                <!-- <i class="fab fa-twitter"></i > -->
+                  <img src="img/x-logo.png" alt="X Logo" width="40px" height="40px" class="x-logo-image">
+                </a>
+              <a
+                href="https://github.com/PriyaGhosal/BuddyTrail"
+                target="_blank"
+                ><i class="fab fa-github"></i
+              ></a>
+              <a
+                href="https://www.linkedin.com/in/priya-ghosal-785771286/"
+                target="_blank"
+                ><i class="fab fa-linkedin-in"></i
+              ></a>
             </div>
+          </div>
+          
+
           </div>
           <p class="copyright">&copy; 2024 BuddyTrail | All rights reserved.</p>
         </div>


### PR DESCRIPTION
 

Fixes:  #1981 

# Description
 
in this pr i am added missing social media icons to disclaimer page footer also keep their animation and functionality same

<!---give the issue number you fixed----->

# Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
 
### Before:

![Screenshot (554)](https://github.com/user-attachments/assets/de0d51e7-928e-4941-995f-2d94d1edff19)


### After:

![Screenshot (555)](https://github.com/user-attachments/assets/1fd23ea5-429f-41a6-80ed-464606bc4f86)


# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [ ] I have made this change from my own.
- [ ] I have taken help from some online resources.
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have tested the changes thoroughly before submitting this pull request.
- [ ] I have provided relevant issue numbers and screenshots after making the changes.

