### PR TITLE
About us page overlap fix of button

### DIFF
--- a/about.html
+++ b/about.html
@@ -311,7 +311,7 @@
                         United by our love for exploration and commitment to excellence, we work tirelessly to ensure
                         your journey with
                         us is seamless, inspiring, and unforgettable.</p>
-                    <div class="align1">
+                    <div class="align1" >
                         <a href="team.html" id="cta-button">The BuddyTrail Team</a>
                     </div>
                 </div>
@@ -329,11 +329,12 @@
 
         .align1 {
             width: 255px;
-            height: 50px;
+            height: auto;
             display: flex;
             align-self: flex-end;
             justify-content: center;
-            margin: 56px auto 56px;
+            margin: 15px auto 56px;
+            margin-top: 5px;
 
         }
 
@@ -642,7 +643,7 @@
             color: #333;
             text-align: center;
             max-width: 900px;
-            margin: 40px auto;
+            margin: 20px auto;
             transition: color 0.3s ease, text-decoration 0.3s ease;
             cursor: pointer;
         }


### PR DESCRIPTION
 

Fixes:  #1989 

# Description

in About us page overlap fix with button and footer  

# Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)

## Before:

![WhatsApp Image 2024-11-10 at 02 38 09_55501c87](https://github.com/user-attachments/assets/8075410d-77a6-4352-8381-64fee84536e3)


## After:

 
![Screenshot (567)](https://github.com/user-attachments/assets/573720f5-e6f7-45c4-9eaa-3677a26b4984)


![Screenshot (568)](https://github.com/user-attachments/assets/0947d952-b38e-4a92-ae06-b2fbdf0cb866)




# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [x] I have made this change from my own.
- [ ] I have taken help from some online resources.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

