### PR TITLE
Fixed homepage visitor counter to track unique visits only once per user session

### DIFF
--- a/visi.js
+++ b/visi.js
@@ -5,9 +5,14 @@ function getVisitorCount() {
 
   // Function to increment and save the count
   function incrementVisitorCount() {
-    let count = parseInt(getVisitorCount()) + 1;
-    localStorage.setItem('visitorCount', count);
-    return count;
+    if (!localStorage.getItem('visitedHomePage')) {
+      let count = parseInt(getVisitorCount()) + 1;
+      localStorage.setItem('visitorCount', count);
+      localStorage.setItem('visitedHomePage', 'true');
+      return count;
+    }
+    
+    return getVisitorCount();
   }
 
   // Function to display the count


### PR DESCRIPTION
## PR : Fixed homepage visitor counter to track unique visits only once per user session

Fix #2000 

## Description
This PR addresses the issue where the visitor count increments each time a user returns to the homepage, even if they have already been counted. The visitor count now only increments on the first visit per user session, ensuring each visitor is counted only once.

@PriyaGhosal Pls assign me this issue, give me labels, level.